### PR TITLE
Consul, SBC, readme changes

### DIFF
--- a/gcp-gke/terraform/README.md
+++ b/gcp-gke/terraform/README.md
@@ -1,3 +1,5 @@
 # Overview
 
-This directory contains examples for the terraform module. You can reuse these files by replacing the dummy variables with the values that match your environment. Inpput and output details of each module can be found on the modules Readme file.
+This directory contains examples for the terraform module. You can reuse these files by replacing the dummy variables with the values that match your environment. Inpput and output details of each module can be found on the modules README files.
+
+Be sure to take a look at the [prerequisites](https://github.com/genesys/multicloud-platform/tree/master/gcp-gke#prerequisites) before executing the code from this directory.

--- a/gcp-gke/terraform/global/0-remotestate/README.md
+++ b/gcp-gke/terraform/global/0-remotestate/README.md
@@ -1,27 +1,28 @@
-
 This example file can be used as follows. Additional details and list of required inputs can be found in the [module documentation](../../../tfm/0-remotestate/README.md)
 
+*Note: Make sure to [authenticate gcloud](https://github.com/genesys/multicloud-platform/tree/master/gcp-gke#authenticate-gcloud) before execution.
+
 1. Execute with the terraform block commented out to create a bucket.
-2. Uncomment the terraform block and move the statefile to the bucket using terraform prompts.
+2. Uncomment the terraform block and move the state file to the bucket by executing code again and following terraform prompts.
 
 ```hcl
 module "remote_state" {
-  source      = "../../../tfm/0-remotestate/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/0-remotestate?ref=master
-  name        = "<your_globally_unique_bucket_name>" (Bucket naming guidlines: https://cloud.google.com/storage/docs/naming-buckets)
-  location    = "<Bucket Location>" (refer: https://cloud.google.com/storage/docs/locations#location-r)
+  source      = "../../../tfm/0-remotestate/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/0-remotestate?ref=master"
+  name        = "<your globally unique bucket name>" #(Refer to: https://cloud.google.com/storage/docs/naming-buckets)
+  location    = "<bucket location>" #(Refer to: https://cloud.google.com/storage/docs/locations#location-r)
 }
 
 #Comment out the below block
 terraform {
   backend "gcs" {
-    bucket = "<your_globally_unique_bucket_name>" #Replace with the name of the bucket created above
-    prefix = "base-state" #creates a new folder within bucket
+    bucket = "<your globally unique bucket name>" #Replace with the name of the bucket created above
+    prefix = "base-state" #Creates a new folder within bucket
   }
 }
 #Commenting ends
 
 provider "google" {
-  project = "<PROJECT ID>"
+  project = "<project ID>"
 }
 
 terraform {
@@ -43,6 +44,6 @@ terraform {
 |------|-------------|------|---------|:--------:|
 | name | Name of the bucket | `string` | n/a | yes |
 | location | Region where the bucket needs to be created | `string` | n/a | yes |
-| project id | Name of the project in provider block where the resources will be created | `string` | n/a | yes |
+| project ID | Name of the project in provider block where the resources will be created | `string` | n/a | yes |
 
 

--- a/gcp-gke/terraform/global/1-network/README.md
+++ b/gcp-gke/terraform/global/1-network/README.md
@@ -5,32 +5,35 @@ This example file can be used as follows. Additional details and list of require
 
 ```hcl
 module "network" {
-    source          = "../../../tfm/1-network/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/1-network?ref=master
+    source          = "../../../tfm/1-network/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/1-network?ref=master"
     provision_vpc   = true/false
-    project_id      = "<PROJECT ID>" eg.gcpe0002
-    network_name    = "<Same as environment>"
-    description     = "<Optional Description>"
-    environment     = "<Environment Name>" eg.gcpe002
-    region          = \[<list of regions>\] eg. \["us-west1","us-east1"\]
-    fqdn            = "<fqdn for your project>" eg. domain.example.com.
+    project_id      = "<project ID>" #eg. project01
+    network_name    = "<name of your VPC network>" #eg. network01
+    description     = "<optional description>"
+    region          = [<list of regions>] #eg. ["us-west1","us-east1"]
+    fqdn            = "<FQDN for your project>" #eg. domain.example.com. (FQDN should have a "." at the end)
 
-    subnets = \[
+    subnets = [
         {
-            subnet_name           = "subnet-01"
-            subnet_ip             = "10.10.10.0/24"
+            subnet_name           = "<VPC network name>-<region>-subnet"
+            subnet_ip             = "10.198.0.0/22"
             subnet_region         = "us-west1"
         },
         {
-            subnet_name           = "subnet-01"
-            subnet_ip             = "10.10.10.0/24"
+            subnet_name           = "<VPC network name>-<region>-vm-subnet"
+            subnet_ip             = "10.198.8.0/22"
             subnet_region         = "us-west1"
-            description           = "This subnet has a description"
+        },
+        {
+            subnet_name           = "<VPC network name>-<region>-privateep-subnet"
+            subnet_ip             = "10.198.4.0/22"
+            subnet_region         = "us-west1"
         }
-    \]
+    ]
 }
 
 provider "google" {
-  project = <PROJECT ID>
+  project = "<project ID>"
 }
 
 terraform {
@@ -46,7 +49,7 @@ terraform {
 
 terraform {
   backend "gcs" {
-    bucket = "<Bucket Name>" #Replace with the name of the bucket created in Module 0
+    bucket = "<your globally unique bucket name>" #replace with the name of the bucket created in module 0
     prefix = "network-state" #creates a new folder within the bucket
   }
 }
@@ -55,7 +58,7 @@ Note: Check the [example file](./main.tf) for sample subnets name and IPs. The s
 
 | Required Subnet Name | Description | Required IPs | Sample CIDR Block | Required |
 |------|-------------|------|---------|:--------:|
-| `<environment>-<subnet-region>-subnet` | Subnet for Kubernetes cluster | 1024 | 10.198.0.0/22 | yes |
-| `<environment>-<subnet-region>-vm-subnet` | Subnet for Virtual Machines | 1024 | 10.198.8.0/22 | yes |
-| `<environment>-<subnet-region>-privateep-subnet` | Subnet for Private Endpoints | 1024 | 10.198.4.0/22 | yes |
+| `<network_name>-<subnet-region>-subnet` | Subnet for Kubernetes cluster | 1024 | 10.198.0.0/22 | yes |
+| `<network_name>-<subnet-region>-vm-subnet` | Subnet for virtual machines | 1024 | 10.198.8.0/22 | yes |
+| `<network_name>-<subnet-region>-privateep-subnet` | Subnet for private endpoints | 1024 | 10.198.4.0/22 | yes |
 

--- a/gcp-gke/terraform/global/1-network/main.tf
+++ b/gcp-gke/terraform/global/1-network/main.tf
@@ -1,40 +1,39 @@
 module "network" {
-    source          = "../../../tfm/1-network/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/1-network?ref=master
+    source          = "../../../tfm/1-network/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/1-network?ref=master"
     provision_vpc   = true
-    project_id      = "project01"
-    network_name    = "network01"
-    environment     = "enviroment01" #For naming conventions; can be the same as project name.
+    project_id      = "project01" 
+    network_name    = "network01" 
     region          = ["us-west1","us-east1"]
-    fqdn            = "domain.example.com."
+    fqdn            = "domain.example.com." 
 
     subnets = [
         {
-            subnet_name           = "enviroment01-us-west1-subnet"
+            subnet_name           = "network01-us-west1-subnet"
             subnet_ip             = "10.198.0.0/22"
             subnet_region         = "us-west1"
         },
         {
-            subnet_name           = "enviroment01-us-west1-vm-subnet"
+            subnet_name           = "network01-us-west1-vm-subnet"
             subnet_ip             = "10.198.8.0/22"
             subnet_region         = "us-west1"
         },
         {
-            subnet_name           = "enviroment01-us-west1-privateep-subnet"
+            subnet_name           = "network01-us-west1-privateep-subnet"
             subnet_ip             = "10.198.4.0/22"
             subnet_region         = "us-west1"
         },
          {
-            subnet_name           = "enviroment01-us-east1-subnet"
+            subnet_name           = "network01-us-east1-subnet"
             subnet_ip             = "10.200.0.0/22"
             subnet_region         = "us-east1"
         },
         {
-            subnet_name           = "enviroment01-us-east1-vm-subnet"
+            subnet_name           = "network01-us-east1-vm-subnet"
             subnet_ip             = "10.200.8.0/22"
             subnet_region         = "us-east1"
         },
         {
-            subnet_name           = "enviroment01-us-east1-privateep-subnet"
+            subnet_name           = "network01-us-east1-privateep-subnet"
             subnet_ip             = "10.200.4.0/22"
             subnet_region         = "us-east1"
         }

--- a/gcp-gke/terraform/global/SBC/7-sbc/sbc-peering/README.md
+++ b/gcp-gke/terraform/global/SBC/7-sbc/sbc-peering/README.md
@@ -1,0 +1,41 @@
+
+
+This example file can be used as follows. Additional details and list of required inputs can be found in the [module documentation]("../../../../../tfm/7-sbc/sbc-peering/README.md)
+
+This module needs to be executed twice. First in project1 to create a peering connection from VPC1 and VPC2 followed by execution in project2 to create a reverse peering connection from VPC2 to VPC1.
+
+*Note: When executing this module in the second project, change the name of the peering connection and switch the primary and peer VPC/project variable values.
+
+```hcl
+module "network-peering" {
+  source                   = "../../../tfm/7-sbc/sbc-peering/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/7-sbc/sbc-peering?ref=master"
+  peering_connection_name  = <name of the peering connection> #eg. "project01-to-sbc-peer"
+  primary_project          = <name of the primary project> #eg. "project01"
+  primary_vpc              = <name of the primary VPC in primary_project> #eg. "network01"
+  peer_project             = <name of the peer project> #eg. "sbc-project"
+  peer_vpc                 = <name of the peer VPC in peer_project>" #eg. "sbc-network"
+}
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "3.52.0"
+    }
+  }
+
+  required_version = "= 1.0.11"
+}
+
+terraform {
+  backend "gcs" {
+    bucket = "<your globally unique bucket name>" #Replace with the name of the bucket created in module 0 or a bucket in the corresponding project
+    prefix = "peering-state-sbc"    #Creates a new folder
+  }
+}
+
+provider "google" {
+  project = "<project ID>"
+}
+```
+

--- a/gcp-gke/terraform/global/SBC/7-sbc/sbc-peering/main.tf
+++ b/gcp-gke/terraform/global/SBC/7-sbc/sbc-peering/main.tf
@@ -1,0 +1,31 @@
+module "network-peering" {
+  source                = "../../../../../tfm/7-sbc/sbc-peering/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/7-sbc/sbc-peering?ref=master"
+  peering_connection_name  = "gcpe002-to-sbc-peer"
+  primary_project       = "project01"
+  primary_vpc           = "network01"
+  peer_project          = "sbc-project"
+  peer_vpc              = "sbc-network"
+  provision_firewall    = true
+}
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "3.52.0"
+    }
+  }
+
+  required_version = "= 1.0.11"
+}
+
+terraform {
+  backend "gcs" {
+    bucket = "tf-statefiles" #Replace with the name of the bucket created in Module 0 or a bucket in the corresponding project
+    prefix = "peering-state-network01"    #creates a new folder
+  }
+}
+
+provider "google" {
+  project = "project01"
+}

--- a/gcp-gke/terraform/useast1/2-gke-cluster/README.md
+++ b/gcp-gke/terraform/useast1/2-gke-cluster/README.md
@@ -2,23 +2,22 @@
 
 This example file can be used as follows. Additional details and list of required inputs can be found in the [module documentation](../../../tfm/2-gke-cluster/README.md)
 
-We have tested this cluster with gke version 1.22.3-gke.700 which was in Rapid release channel at the time, for the updated release channels and versions please check the official [Release Notes](https://cloud.google.com/kubernetes-engine/docs/release-notes). Basic usage of this module is as follows:
+We have tested this cluster with GKE version 1.23.10-gke.1000 which was in the RAPID release channel at the time, for the updated release channels and versions please check the official [Release Notes](https://cloud.google.com/kubernetes-engine/docs/release-notes). Basic usage of this module is as follows:
 
 
 ```hcl
 module "gke" {
-    source                  = "../../../tfm/2-gke-cluster/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/2-gke-cluster?ref=master"
-    project_id              = "<project ID> eg.gcpe0003"
-    environment             = "<environment> eg.gcpe003"
-    network_name            = "<network> eg.gcpe003"
-    region                  = "<cluster region> eg.us-west1"
-    cluster                 = "<cluster name> eg.gke1"
-    gke_version             = "<version of the cluster>" #Minumum version supported: 1.22
-    release_channel         = "<release channel> eg.RAPID/REGULAR/STABLE" #must be all caps
-    secondary_pod_range     = "<CIDR block for pods> eg.10.198.64.0/18"
-    secondary_service_range = "<CIDR block for services> 10.198.16.0/20"
+    source                  = "../../../tfm/2-gke-cluster/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/2-gke-cluster?ref=master"
+    project_id              = "<project ID>" #eg. project01
+    network_name            = "<network>" #eg. network01
+    region                  = "<cluster region>" #eg. us-west1
+    cluster                 = "<cluster name>" #eg. cluster01
+    gke_version             = "<version of the cluster>" #minumum version supported: 1.23
+    release_channel         = "<release channel>" #eg. RAPID/REGULAR/STABLE/UNSPECIFIED (must be all caps)
+    secondary_pod_range     = "<CIDR block for pods>" #eg. 10.198.64.0/18
+    secondary_service_range = "<CIDR block for services>" #eg. 10.198.16.0/20
     gke_num_nodes           = "2"
-    windows_node_pool       = false #Optional parameter.Needs to be specified if node pool needs to be windows.By default it is false and will create a GKE cluster with linux node pool.
+    windows_node_pool       = false #Optional parameter. Needs to be specified if node pool needs to be windows. By default it is false and will create a GKE cluster with Linux node pool.
 }
 
 terraform {
@@ -34,8 +33,8 @@ terraform {
 
 terraform {
     backend "gcs" {
-        bucket = <Bucket Name> #Replace with the name of the bucket created in Module 0
-        prefix = "cluster-state" #creates a new folder within the bucket
+        bucket = "<your globally unique bucket name>" #Replace with the name of the bucket created in module 0
+        prefix = "cluster-state" #Creates a new folder within the bucket
     }
 }
 ```

--- a/gcp-gke/terraform/useast1/2-gke-cluster/main.tf
+++ b/gcp-gke/terraform/useast1/2-gke-cluster/main.tf
@@ -1,12 +1,11 @@
 module "gke" {
     source                  = "../../../tfm/2-gke-cluster/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/2-gke-cluster?ref=master
     project_id              = "project01"
-    environment             = "environment01" #can be same as project name
     network_name            = "network01"
     region                  = "us-east1"
     cluster                 = "cluster01"
-    gke_version             = "1.21.6-gke.1503" #Minumum version supported: 1.21.*
-    release_channel         = "REGULAR" 
+    gke_version             = "1.23.10-gke.1000" #Minumum version supported: 1.21.*
+    release_channel         = "UNSPECIFIED" 
     secondary_pod_range     = "10.200.64.0/18"
     secondary_service_range = "10.200.16.0/20"
     gke_num_nodes           = "2"

--- a/gcp-gke/terraform/useast1/3-k8s-setup/README.md
+++ b/gcp-gke/terraform/useast1/3-k8s-setup/README.md
@@ -2,28 +2,28 @@ This example file can be used as follows. Additional details and list of require
 
 ```hcl
 module "network" {
-    source        = "../../../tfm/3-k8s-setup/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/3-k8s-setup?ref=master"
-    project_id    = "<PROJECT ID eg.gcpe0002>"
-    network_name  = "<Same as environment>"
-    ipv4          = "<Reserved ipv4 CIDR for storage class>" #1024 IP addresses
+    source        = "../../../tfm/3-k8s-setup/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/3-k8s-setup?ref=master"
+    project_id    = "<project ID>" #eg. project01
+    network_name  = "<name of your VPC network>" #eg. network01
+    ipv4          = "<reserved IPv4 CIDR for storage class>" #1024 IP addresses
 }
 
 
 provider "google" {
-  project = <PROJECT ID>
+  project = "<project ID>"
 }
 
-data "google_container_cluster" "gke1" {
+data "google_container_cluster" "<cluster name>" {
   name = "<cluster name>"
   location = "<cluster region>"
-  project = "<project id>"
+  project = "<project ID>"
 }
 
 provider "kubernetes" {
-  host = "https://${data.google_container_cluster.gke1.endpoint}"
+  host = "https://${data.google_container_cluster.<cluster name>.endpoint}"
   token = data.google_client_config.provider.access_token
   cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
   ) 
 }
 
@@ -37,10 +37,10 @@ default = "v2.9.1"
 
 provider "helm" {
   kubernetes {
-    host = "https://${data.google_container_cluster.gke1.endpoint}"
+    host = "https://${data.google_container_cluster.<cluster name>.endpoint}"
     token = data.google_client_config.provider.access_token
     cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
     )
     config_path = "~/.kube/config"
   } 
@@ -59,8 +59,8 @@ terraform {
 
 terraform {
   backend "gcs" {
-    bucket = <Bucket Name> #Replace with the name of the bucket created in Module 0
-    prefix = "gke1-k8s-state" #creates a new folder within the bucket
+    bucket = "<your globally unique bucket name>" #Replace with the name of the bucket created in module 0
+    prefix = "<cluster name>-k8s-state" #Creates a new folder within the bucket
   }
 }
 ```

--- a/gcp-gke/terraform/useast1/4-certs/README.md
+++ b/gcp-gke/terraform/useast1/4-certs/README.md
@@ -2,28 +2,28 @@ This example file can be used as follows. Additional details and list of require
 
 ```hcl
 module "ingress_certs" {
-  source            = "../../../tfm/4-ingress-certs/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/4-ingress-certs?ref=master
-  project_id        = "<project id>" eg.gcpe0003
-  environment       = "<The environment where these resources will get created>" eg.gcpe003
-  domain_name_nginx = "<domain name>" 
-  email             = "<john@example.com>"
+  source            = "../../../tfm/4-ingress-certs/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/4-ingress-certs?ref=master"
+  project_id        = "<project ID>" #eg. project01
+  network_name      = "<name of the VPC network>" #eg. network01
+  domain_name_nginx = "<domain name>" #eg. lb01-useast1.domain.example.com (domain.example.com should be same as FQDN in module 1)
+  email             = "<email for certificate issuers>" #eg. jane.doe@email.com
 }
 
 #Kubernetes
 
 data "google_client_config" "provider" {}
 
-data "google_container_cluster" "gke1" {
+data "google_container_cluster" "<cluster name>" {
   name = "<cluster name>"
   location = "<cluster region>"
   project = "<project ID>"
 }
 
 provider "kubernetes" {
-  host = "https://${data.google_container_cluster.gke1.endpoint}"
+  host = "https://${data.google_container_cluster.<cluster name>.endpoint}"
   token = data.google_client_config.provider.access_token
   cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
   ) 
 }
 
@@ -35,10 +35,10 @@ default = "v2.9.1"
 
 provider "helm" {
   kubernetes {
-    host = "https://${data.google_container_cluster.gke1.endpoint}"
+    host = "https://${data.google_container_cluster.<cluster name>.endpoint}"
     token = data.google_client_config.provider.access_token
     cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
     )
     config_path = "~/.kube/config"
   } 
@@ -46,7 +46,7 @@ provider "helm" {
 
 
 provider "google" {
-  project = <PROJECT ID>
+  project = <project ID>
 }
 
 terraform {
@@ -62,8 +62,8 @@ terraform {
 
 terraform {
   backend "gcs" {
-    bucket =  <Bucket Name>  #Replace with the name of the bucket created in Module 0
-    prefix = "ingress-state" #creates a new folder within the bucket
+    bucket =  "<your globally unique bucket name>"  #Replace with the name of the bucket created in module 0
+    prefix = "ingress-state" #Creates a new folder within the bucket
   }
 }
 

--- a/gcp-gke/terraform/useast1/5-thirdparty/README.md
+++ b/gcp-gke/terraform/useast1/5-thirdparty/README.md
@@ -2,22 +2,26 @@ This example file can be used as follows. Additional details and list of require
 
 ```hcl
 module "third-party" {
-    source  = "../../../tfm/5-third-party/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/5-third-party?ref=master
+    source  = "../../../tfm/5-third-party/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/5-third-party?ref=master"
+    consul_helm_version = "0.41.0"
+    consul_image        = "hashicorp/consul:1.11.3"
+    consul_imageK8S     = "hashicorp/consul-k8s-control-plane:0.41.0"
+    consul_datacenter   = "useast1"
 }
 
 #Kubernetes
 data "google_client_config" "provider" {}
-data "google_container_cluster" "gke1" {
+data "google_container_cluster" "<cluster name>" {
   name     = <cluster name>
   location = <cluster location>
-  project  = <project name>
+  project  = <project ID>
 }
 
 provider "kubernetes" {
-  host  = "https://${data.google_container_cluster.gke1.endpoint}"
+  host  = "https://${data.google_container_cluster.<cluster name>.endpoint}"
   token = data.google_client_config.provider.access_token
   cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
     #google_container_cluster.primary.master_auth.0.cluster_ca_certificate
   )
 }
@@ -30,10 +34,10 @@ variable "helm_version" {
 provider "helm" {
 
   kubernetes {
-    host  = "https://${data.google_container_cluster.gke1.endpoint}"
+    host  = "https://${data.google_container_cluster.<cluster name>.endpoint}"
     token = data.google_client_config.provider.access_token
     cluster_ca_certificate = base64decode(
-      data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+      data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
       #google_container_cluster.primary.master_auth.0.cluster_ca_certificate
     )
     config_path = "~/.kube/config"
@@ -41,7 +45,7 @@ provider "helm" {
 }
 
 provider "google" {
-  project = <project name>
+  project = <project ID>
 }
 
 terraform {
@@ -57,8 +61,8 @@ terraform {
 
 terraform {
     backend "gcs" {
-        bucket = <Bucket Name> #Replace with the name of the bucket created in Module 0
-        prefix = "third-party-state" #creates a new folder within bucket
+        bucket = "<your globally unique bucket name>" #Replace with the name of the bucket created in module 0
+        prefix = "third-party-state" #Creates a new folder within bucket
     }
 }
 ```

--- a/gcp-gke/terraform/useast1/5-thirdparty/main.tf
+++ b/gcp-gke/terraform/useast1/5-thirdparty/main.tf
@@ -1,5 +1,9 @@
 module "third-party" {
     source  = "../../../tfm/5-third-party/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/5-third-party?ref=master
+    consul_helm_version = "0.41.0"
+    consul_image        = "hashicorp/consul:1.11.3"
+    consul_imageK8S     = "hashicorp/consul-k8s-control-plane:0.41.0"
+    consul_datacenter   = "useast1"
 }
 
 

--- a/gcp-gke/terraform/useast1/6-jumphost/README.md
+++ b/gcp-gke/terraform/useast1/6-jumphost/README.md
@@ -2,15 +2,15 @@ This example file can be used as follows. Additional details and list of require
 
 ```hcl
 module "jumphost_instance" {
-    source          = "../../../tfm/6-jumphost/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/6-jumphost?ref=master
-    project         = "<PROJECT ID>" eg.gcpe0003
-    description     = "<Optional Description>"
-    name            = "<your_machine_name>"
-    machine_type    = "<Machine_tyep>" eg.e2-micro
-    zone            = "<zone>" eg.us-central1-a   
-    image           = "<OS_image_name>" eg.ubuntu-os-cloud/ubuntu-1804-lts
-    network         = "<VPC Network ID>"
-    subnetwork      = "<Subnet of Network>"
+    source          = "../../../tfm/6-jumphost/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/6-jumphost?ref=master"
+    project         = "<project ID>" #eg. project01
+    description     = "<optional description>"
+    name            = "<your machine name>" #eg. cluster01-jumphost
+    machine_type    = "<machine type>" #eg. e2-micro
+    zone            = "<zone>" #eg. us-central1-a   
+    image           = "<OS image name>" #eg. ubuntu-os-cloud/ubuntu-1804-lts
+    network         = "<VPC network name>" #eg. network01
+    subnetwork      = "<subnet of network>"
     provision_ssh_firewall = true
     provision_iap_firewall = true
     create_iap_iam_role    = true
@@ -19,7 +19,7 @@ module "jumphost_instance" {
 }
 
 provider "google" {
-  project = "<PROJECT ID>"
+  project = "<project ID>"
 }
 
 terraform {
@@ -35,8 +35,8 @@ terraform {
 
 terraform {
   backend "gcs" {
-    bucket = <Bucket Name>  #Replace with the name of the bucket created in Module 0
-    prefix = "jumphost-state" #creates a new folder within bucket
+    bucket = "<your globally unique bucket name>"  #Replace with the name of the bucket created in Module 0
+    prefix = "jumphost-state" #Creates a new folder within bucket
   }
 }
 ```

--- a/gcp-gke/terraform/useast1/6-jumphost/main.tf
+++ b/gcp-gke/terraform/useast1/6-jumphost/main.tf
@@ -6,7 +6,7 @@ module "jumphost_instance" {
     zone            = "us-east1-c" 
     image           = "ubuntu-os-cloud/ubuntu-1804-lts"    
     network         = "network01"
-    subnetwork      = "enviroment01-us-west1-vm-subnet"
+    subnetwork      = "network01-us-west1-vm-subnet"
     provision_ssh_firewall = true
     provision_iap_firewall = true
     create_iap_iam_role    = true

--- a/gcp-gke/terraform/useast1/SBC/7-sbc/sbc-setup/main.tf
+++ b/gcp-gke/terraform/useast1/SBC/7-sbc/sbc-setup/main.tf
@@ -1,9 +1,10 @@
-module "ingress_certs" {
-  source            = "../../../tfm/4-ingress-certs/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/4-ingress-certs?ref=master
-  project_id        = "project01"
-  network_name      = "network01"
-  domain_name_nginx = "lb01-useast1.domain.example.com" #domain.example.com should be same as FQDN in module 1-network
-  email             = "jane.doe@email.com"
+module "sbc-setup" {
+  source               = "../../../../../tfm/7-sbc/sbc-setup/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/7-sbc/sbc-setup?ref=master"
+  network_name         = "network01"
+  subnetwork           = "network01-us-east1-subnet"
+  region               = "us-east1"
+  ip_name              = "sip-address-useast1"
+  provision_firewall_ingress   = true
 }
 
 #Kubernetes
@@ -57,9 +58,10 @@ terraform {
   required_version = "= 1.0.11"
 }
 
+
 terraform {
   backend "gcs" {
-    bucket = "tf-statefiles" #Replace with the name of the bucket created in module 0-remotestate
-    prefix = "ingress-certs-cluster01-useast1-state" #creates a new folder
+    bucket = "tf-statefiles" #Replace with the name of the bucket created in Module 0
+    prefix = "sbc-setup-useast1-state" #creates a new folder within the bucket
   }
 }

--- a/gcp-gke/terraform/uswest1/2-gke-cluster/README.md
+++ b/gcp-gke/terraform/uswest1/2-gke-cluster/README.md
@@ -2,23 +2,22 @@
 
 This example file can be used as follows. Additional details and list of required inputs can be found in the [module documentation](../../../tfm/2-gke-cluster/README.md)
 
-We have tested this cluster with gke version 1.22.3-gke.700 which was in Rapid release channel at the time, for the updated release channels and versions please check the official [Release Notes](https://cloud.google.com/kubernetes-engine/docs/release-notes). Basic usage of this module is as follows:
+We have tested this cluster with GKE version 1.23.10-gke.1000 which was in the RAPID release channel at the time, for the updated release channels and versions please check the official [Release Notes](https://cloud.google.com/kubernetes-engine/docs/release-notes). Basic usage of this module is as follows:
 
 
 ```hcl
 module "gke" {
-    source                  = "../../../tfm/2-gke-cluster/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/2-gke-cluster?ref=master"
-    project_id              = "<project ID> eg.gcpe0003"
-    environment             = "<environment> eg.gcpe003"
-    network_name            = "<network> eg.gcpe003"
-    region                  = "<cluster region> eg.us-west1"
-    cluster                 = "<cluster name> eg.gke1"
-    gke_version             = "<version of the cluster>" #Minumum version supported: 1.22
-    release_channel         = "<release channel> eg.RAPID/REGULAR/STABLE" #must be all caps
-    secondary_pod_range     = "<CIDR block for pods> eg.10.198.64.0/18"
-    secondary_service_range = "<CIDR block for services> 10.198.16.0/20"
+    source                  = "../../../tfm/2-gke-cluster/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/2-gke-cluster?ref=master"
+    project_id              = "<project ID>" #eg. project01
+    network_name            = "<network>" #eg. network01
+    region                  = "<cluster region>" #eg. us-west1
+    cluster                 = "<cluster name>" #eg. cluster02
+    gke_version             = "<version of the cluster>" #minumum version supported: 1.23
+    release_channel         = "<release channel>" #eg. RAPID/REGULAR/STABLE/UNSPECIFIED (must be all caps)
+    secondary_pod_range     = "<CIDR block for pods>" #eg. 10.198.64.0/18
+    secondary_service_range = "<CIDR block for services>" #eg. 10.198.16.0/20
     gke_num_nodes           = "2"
-    windows_node_pool       = false #Optional parameter.Needs to be specified if node pool needs to be windows.By default it is false and will create a GKE cluster with linux node pool.
+    windows_node_pool       = false #Optional parameter. Needs to be specified if node pool needs to be windows. By default it is false and will create a GKE cluster with Linux node pool.
 }
 
 terraform {
@@ -34,8 +33,8 @@ terraform {
 
 terraform {
     backend "gcs" {
-        bucket = <Bucket Name> #Replace with the name of the bucket created in Module 0
-        prefix = "cluster-state" #creates a new folder within the bucket
+        bucket = "<your globally unique bucket name>" #Replace with the name of the bucket created in module 0
+        prefix = "cluster-state" #Creates a new folder within the bucket
     }
 }
 ```

--- a/gcp-gke/terraform/uswest1/2-gke-cluster/main.tf
+++ b/gcp-gke/terraform/uswest1/2-gke-cluster/main.tf
@@ -1,12 +1,11 @@
 module "gke" {
     source                  = "../../../tfm/2-gke-cluster/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/2-gke-cluster?ref=master
     project_id              = "project01"
-    environment             = "environment01"
     network_name            = "network01"
     region                  = "us-west1"
     cluster                 = "cluster02"
-    gke_version             = "1.21.6-gke.1503" #Minumum version supported: 1.21.*
-    release_channel         = "REGULAR" 
+    gke_version             = "1.22.10-gke.600"  #Minumum version supported: 1.21.*
+    release_channel         = "UNSPECIFIED" 
     secondary_pod_range     = "10.198.64.0/18"
     secondary_service_range = "10.198.16.0/20"
     gke_num_nodes           = "2"

--- a/gcp-gke/terraform/uswest1/3-k8s-setup/README.md
+++ b/gcp-gke/terraform/uswest1/3-k8s-setup/README.md
@@ -2,28 +2,28 @@ This example file can be used as follows. Additional details and list of require
 
 ```hcl
 module "network" {
-    source        = "../../../tfm/3-k8s-setup/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/3-k8s-setup?ref=master"
-    project_id    = "<PROJECT ID eg.gcpe0002>"
-    network_name  = "<Same as environment>"
-    ipv4          = "<Reserved ipv4 CIDR for storage class>" #1024 IP addresses
+    source        = "../../../tfm/3-k8s-setup/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/3-k8s-setup?ref=master"
+    project_id    = "<project ID>" #eg. project01
+    network_name  = "<name of your VPC network>" #eg. network01
+    ipv4          = "<reserved IPv4 CIDR for storage class>" #1024 IP addresses
 }
 
 
 provider "google" {
-  project = <PROJECT ID>
+  project = "<project ID>"
 }
 
-data "google_container_cluster" "gke1" {
+data "google_container_cluster" "<cluster name>" {
   name = "<cluster name>"
   location = "<cluster region>"
-  project = "<project id>"
+  project = "<project ID>"
 }
 
 provider "kubernetes" {
-  host = "https://${data.google_container_cluster.gke1.endpoint}"
+  host = "https://${data.google_container_cluster.<cluster name>.endpoint}"
   token = data.google_client_config.provider.access_token
   cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
   ) 
 }
 
@@ -37,10 +37,10 @@ default = "v2.9.1"
 
 provider "helm" {
   kubernetes {
-    host = "https://${data.google_container_cluster.gke1.endpoint}"
+    host = "https://${data.google_container_cluster.<cluster name>.endpoint}"
     token = data.google_client_config.provider.access_token
     cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
     )
     config_path = "~/.kube/config"
   } 
@@ -59,8 +59,8 @@ terraform {
 
 terraform {
   backend "gcs" {
-    bucket = <Bucket Name> #Replace with the name of the bucket created in Module 0
-    prefix = "gke1-k8s-state" #creates a new folder within the bucket
+    bucket = "<your globally unique bucket name>" #Replace with the name of the bucket created in module 0
+    prefix = "gke1-k8s-state" #Creates a new folder within the bucket
   }
 }
 ```

--- a/gcp-gke/terraform/uswest1/4-certs/README.md
+++ b/gcp-gke/terraform/uswest1/4-certs/README.md
@@ -2,28 +2,28 @@ This example file can be used as follows. Additional details and list of require
 
 ```hcl
 module "ingress_certs" {
-  source            = "../../../tfm/4-ingress-certs/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/4-ingress-certs?ref=master
-  project_id        = "<project id>" eg.gcpe0003
-  environment       = "<The environment where these resources will get created>" eg.gcpe003
-  domain_name_nginx = "<domain name>" 
-  email             = "<john@example.com>"
+  source            = "../../../tfm/4-ingress-certs/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/4-ingress-certs?ref=master"
+  project_id        = "<project ID>" #eg. project01
+  network_name      = "<name of the VPC network>" #eg. network01
+  domain_name_nginx = "<domain name>" #eg. lb02-useast1.domain.example.com (domain.example.com should be same as FQDN in module 1)
+  email             = "<email for certificate issuers>" #eg. jane.doe@email.com
 }
 
 #Kubernetes
 
 data "google_client_config" "provider" {}
 
-data "google_container_cluster" "gke1" {
+data "google_container_cluster" "<cluster name>" {
   name = "<cluster name>"
   location = "<cluster region>"
   project = "<project ID>"
 }
 
 provider "kubernetes" {
-  host = "https://${data.google_container_cluster.gke1.endpoint}"
+  host = "https://${data.google_container_cluster.<cluster name>.endpoint}"
   token = data.google_client_config.provider.access_token
   cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
   ) 
 }
 
@@ -35,10 +35,10 @@ default = "v2.9.1"
 
 provider "helm" {
   kubernetes {
-    host = "https://${data.google_container_cluster.gke1.endpoint}"
+    host = "https://${data.google_container_cluster.<cluster name>.endpoint}"
     token = data.google_client_config.provider.access_token
     cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
     )
     config_path = "~/.kube/config"
   } 
@@ -46,7 +46,7 @@ provider "helm" {
 
 
 provider "google" {
-  project = <PROJECT ID>
+  project = "<project ID>"
 }
 
 terraform {
@@ -62,8 +62,8 @@ terraform {
 
 terraform {
   backend "gcs" {
-    bucket =  <Bucket Name>  #Replace with the name of the bucket created in Module 0
-    prefix = "ingress-state" #creates a new folder within the bucket
+    bucket =  "<your globally unique bucket name>"  #Replace with the name of the bucket created in module 0
+    prefix = "ingress-state" #Creates a new folder within the bucket
   }
 }
 

--- a/gcp-gke/terraform/uswest1/4-certs/main.tf
+++ b/gcp-gke/terraform/uswest1/4-certs/main.tf
@@ -1,8 +1,8 @@
 module "ingress_certs" {
   source            = "../../../tfm/4-ingress-certs/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/4-ingress-certs?ref=master
   project_id        = "project01"
-  environment       = "environment01"
-  domain_name_nginx = "nlb02-uswest1.domain.example.com" #domain.example.com should be same as FQDN in module 1-network
+  network_name      = "network01"
+  domain_name_nginx = "lb02-uswest1.domain.example.com" #domain.example.com should be same as FQDN in module 1-network
   email             = "jane.doe@email.com"
 }
 

--- a/gcp-gke/terraform/uswest1/5-thirdparty/README.md
+++ b/gcp-gke/terraform/uswest1/5-thirdparty/README.md
@@ -2,22 +2,26 @@ This example file can be used as follows. Additional details and list of require
 
 ```hcl
 module "third-party" {
-    source  = "../../../tfm/5-third-party/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/5-third-party?ref=master
+    source  = "../../../tfm/5-third-party/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/5-third-party?ref=master"
+    consul_helm_version = "0.41.0"
+    consul_image        = "hashicorp/consul:1.11.3"
+    consul_imageK8S     = "hashicorp/consul-k8s-control-plane:0.41.0"
+    consul_datacenter   = "uswest1"
 }
 
 #Kubernetes
 data "google_client_config" "provider" {}
-data "google_container_cluster" "gke1" {
+data "google_container_cluster" "<cluster name>" {
   name     = <cluster name>
   location = <cluster location>
-  project  = <project name>
+  project  = <project ID>
 }
 
 provider "kubernetes" {
-  host  = "https://${data.google_container_cluster.gke1.endpoint}"
+  host  = "https://${data.google_container_cluster.<cluster name>.endpoint}"
   token = data.google_client_config.provider.access_token
   cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
     #google_container_cluster.primary.master_auth.0.cluster_ca_certificate
   )
 }
@@ -30,10 +34,10 @@ variable "helm_version" {
 provider "helm" {
 
   kubernetes {
-    host  = "https://${data.google_container_cluster.gke1.endpoint}"
+    host  = "https://${data.google_container_cluster.<cluster name>.endpoint}"
     token = data.google_client_config.provider.access_token
     cluster_ca_certificate = base64decode(
-      data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+      data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
       #google_container_cluster.primary.master_auth.0.cluster_ca_certificate
     )
     config_path = "~/.kube/config"
@@ -41,7 +45,7 @@ provider "helm" {
 }
 
 provider "google" {
-  project = <project name>
+  project = "<project ID>"
 }
 
 terraform {
@@ -57,8 +61,8 @@ terraform {
 
 terraform {
     backend "gcs" {
-        bucket = <Bucket Name> #Replace with the name of the bucket created in Module 0
-        prefix = "third-party-state" #creates a new folder within bucket
+        bucket = "<your globally unique bucket name>" #Replace with the name of the bucket created in module 0
+        prefix = "third-party-state" #Creates a new folder within bucket
     }
 }
 ```

--- a/gcp-gke/terraform/uswest1/5-thirdparty/main.tf
+++ b/gcp-gke/terraform/uswest1/5-thirdparty/main.tf
@@ -2,6 +2,10 @@
 
 module "third-party" {
     source  = "../../../tfm/5-third-party/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/5-third-party?ref=master
+    consul_helm_version = "0.41.0"
+    consul_image        = "hashicorp/consul:1.11.3"
+    consul_imageK8S     = "hashicorp/consul-k8s-control-plane:0.41.0"
+    consul_datacenter   = "uswest1"
 }
 
 

--- a/gcp-gke/terraform/uswest1/6-jumphost/README.md
+++ b/gcp-gke/terraform/uswest1/6-jumphost/README.md
@@ -2,15 +2,15 @@ This example file can be used as follows. Additional details and list of require
 
 ```hcl
 module "jumphost_instance" {
-    source          = "../../../tfm/6-jumphost/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/6-jumphost?ref=master
-    project         = "<PROJECT ID>" eg.gcpe0003
-    description     = "<Optional Description>"
-    name            = "<your_machine_name>"
-    machine_type    = "<Machine_tyep>" eg.e2-micro
-    zone            = "<zone>" eg.us-central1-a   
-    image           = "<OS_image_name>" eg.ubuntu-os-cloud/ubuntu-1804-lts
-    network         = "<VPC Network ID>"
-    subnetwork      = "<Subnet of Network>"
+    source          = "../../../tfm/6-jumphost/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/6-jumphost?ref=master"
+    project         = "<project ID>" #eg. project01
+    description     = "<optional description>"
+    name            = "<your machine name>" #eg. cluster02-jumphost
+    machine_type    = "<machine type>" #eg. e2-micro
+    zone            = "<zone>" #eg. us-central1-a   
+    image           = "<OS image name>" #eg. ubuntu-os-cloud/ubuntu-1804-lts
+    network         = "<VPC network name>" #eg. network01
+    subnetwork      = "<subnet of network>"
     provision_ssh_firewall = true
     provision_iap_firewall = true
     create_iap_iam_role    = true
@@ -19,7 +19,7 @@ module "jumphost_instance" {
 }
 
 provider "google" {
-  project = "<PROJECT ID>"
+  project = "<project ID>"
 }
 
 terraform {
@@ -35,8 +35,8 @@ terraform {
 
 terraform {
   backend "gcs" {
-    bucket = <Bucket Name>  #Replace with the name of the bucket created in Module 0
-    prefix = "jumphost-state" #creates a new folder within bucket
+    bucket = "<your globally unique bucket name>"  #Replace with the name of the bucket created in module 0
+    prefix = "jumphost-state" #Creates a new folder within bucket
   }
 }
 ```

--- a/gcp-gke/terraform/uswest1/6-jumphost/main.tf
+++ b/gcp-gke/terraform/uswest1/6-jumphost/main.tf
@@ -6,10 +6,10 @@ module "jumphost_instance" {
     zone            = "us-west1-a" 
     image           = "ubuntu-os-cloud/ubuntu-1804-lts"    
     network         = "network01"
-    subnetwork      = "enviroment01-us-east1-vm-subnet"
+    subnetwork      = "network01-us-east1-vm-subnet"
     provision_ssh_firewall = false
     provision_iap_firewall = false
-    
+    members         = ["user:jane@email.com", "user:john@email.com"] 
     
 }
 

--- a/gcp-gke/terraform/uswest1/SBC/7-sbc/sbc-setup/main.tf
+++ b/gcp-gke/terraform/uswest1/SBC/7-sbc/sbc-setup/main.tf
@@ -1,8 +1,10 @@
-module "k8s-setup" {
-    source        = "../../../tfm/3-k8s-setup/" #github.com/genesys/multicloud-platform.git//gcp-gke/tfm/3-k8s-setup?ref=master"
-    project_id   = "project01"
-    network_name = "network01"
-    ipv4         = "10.198.12.0/22"
+module "sbc-setup" {
+  source               = "../../../../../tfm/7-sbc/sbc-setup/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/7-sbc/sbc-setup?ref=master"
+  network_name         = "network01"
+  subnetwork           = "network01-us-west1-subnet"
+  region               = "us-west1"
+  ip_name               = "sip-address-uswest1"
+  provision_firewall_ingress   = false
 }
 
 data "google_client_config" "provider" {}
@@ -13,10 +15,6 @@ data "google_container_cluster" "cluster02" {
   project = "project01"
 }
 
-provider "google" {
-  project = "project01"
-}
-
 provider "kubernetes" {
   host = "https://${data.google_container_cluster.cluster02.endpoint}"
   token = data.google_client_config.provider.access_token
@@ -24,6 +22,8 @@ provider "kubernetes" {
     data.google_container_cluster.cluster02.master_auth[0].cluster_ca_certificate,
   ) 
 }
+
+#Helm
 
 variable "helm_version" {
 default = "v2.9.1"
@@ -40,6 +40,11 @@ provider "helm" {
   } 
 }
 
+
+provider "google" {
+  project = "project01"
+}
+
 terraform {
   required_providers {
     google = {
@@ -53,7 +58,7 @@ terraform {
 
 terraform {
   backend "gcs" {
-    bucket = "tf-statefiles" 
-    prefix = "k8s-setup-cluster02-uswest1-state" #creates a new folder
+    bucket = "tf-statefiles"  #Replace with the name of the bucket created in Module 0
+    prefix = "sbc-setup-uswest1-state" #creates a new folder within the bucket
   }
 }

--- a/gcp-gke/tfm/0-remotestate/README.md
+++ b/gcp-gke/tfm/0-remotestate/README.md
@@ -4,30 +4,32 @@ This module handles the inital setup for terraform backend and enabling GKE API'
 
 ## Usage
 
+*Note: Make sure to [authenticate gcloud](https://github.com/genesys/multicloud-platform/tree/master/gcp-gke#authenticate-gcloud) before execution.
+
 This module needs to be executed twice. First time for creating the initial bucket. Second time for moving the state file to the newly created bucket.
 Basic usage of this module is as follows:
 
 1. Execute with the terraform block commented out to create a bucket.
-2. Uncomment the terraform block and move the statefile to the bucket using terraform prompts.
+2. Uncomment the terraform block and move the statefile to the bucket by executing code again and following terraform prompts. 
 
 ```hcl
 module "remote_state" {
-  source      = "github.com/genesys/multicloud-platform.git//gcp-gke/tfm/0-remotestate?ref=master"
-  name        = "<your_globally_unique_bucket_name>" (Bucket naming guidlines: https://cloud.google.com/storage/docs/naming-buckets)
-  location    = "<Bucket Location>" (Regions list: https://cloud.google.com/storage/docs/locations#location-r)
+  source      = "../../../tfm/0-remotestate/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/0-remotestate?ref=master"
+  name        = "<your globally unique bucket name>" #(Bucket naming guidlines: https://cloud.google.com/storage/docs/naming-buckets)
+  location    = "<bucket location>" #(Regions list: https://cloud.google.com/storage/docs/locations#location-r)
 }
 
 #Comment out the below block
 terraform {
   backend "gcs" {
-    bucket = "<your_globally_unique_bucket_name>" #Replace with the name of the bucket created above
-    prefix = "remotestate-state" #creates a new folder within bucket
+    bucket = "<your globally unique bucket name>" #Replace with the name of the bucket created above
+    prefix = "remotestate-state" #Creates a new folder within bucket
   }
 }
 #Commenting ends
 
 provider "google" {
-  project = "<PROJECT ID>"
+  project = "<project ID>"
 }
 
 terraform {

--- a/gcp-gke/tfm/0-remotestate/variables.tf
+++ b/gcp-gke/tfm/0-remotestate/variables.tf
@@ -1,3 +1,4 @@
+# https://cloud.google.com/storage/docs/naming-buckets)
 variable "name" {
   type = string
   description = "Name of the bucket"
@@ -6,7 +7,7 @@ variable "name" {
 # https://cloud.google.com/storage/docs/locations#location-r
 variable "location" {
   type = string
-  description = "location of the bucket"
+  description = "Location of the bucket"
   #default     = "US"
 }
 

--- a/gcp-gke/tfm/1-network/README.md
+++ b/gcp-gke/tfm/1-network/README.md
@@ -11,37 +11,39 @@ This module supports creating:
 
 ## Usage
 
-Basic usage of this module is as follows:
+Basic usage of this module is as follows: 
 
 ```hcl
 module "network" {
-
-    source          = "github.com/genesys/multicloud-platform.git//gcp-gke/tfm/1-network?ref=master"
+    source          = "../../../tfm/1-network/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/1-network?ref=master"
     provision_vpc   = true/false
-    project_id      = "<PROJECT ID>" eg.gcpe0002
-    network_name    = "<Same as environment>"
-    description     = "<Optional Description>"
-    environment     = "<Environment Name>" eg.gcpe002
-    region          = \[<list of regions>\] eg. \["us-west1","us-east1"\]
-    fqdn            = "<fqdn for your project>" eg. domain.example.com.
+    project_id      = "<project ID>" #eg. project01
+    network_name    = "<name of your VPC network>" #eg. network01
+    description     = "<optional description>"
+    region          = [<list of regions>] #eg. ["us-west1","us-east1"]
+    fqdn            = "<FQDN for your project>" #eg. domain.example.com. (FQDN should have a "." at the end)
 
-    subnets = \[
+    subnets = [
         {
-            subnet_name           = "subnet-01"
-            subnet_ip             = "10.10.10.0/24"
+            subnet_name           = "<VPC network name>-<region>-subnet"
+            subnet_ip             = "10.198.0.0/22"
             subnet_region         = "us-west1"
         },
         {
-            subnet_name           = "subnet-01"
-            subnet_ip             = "10.10.10.0/24"
+            subnet_name           = "<VPC network name>-<region>-vm-subnet"
+            subnet_ip             = "10.198.8.0/22"
             subnet_region         = "us-west1"
-            description           = "This subnet has a description"
+        },
+        {
+            subnet_name           = "<VPC network name>-<region>-privateep-subnet"
+            subnet_ip             = "10.198.4.0/22"
+            subnet_region         = "us-west1"
         }
-    \]
+    ]
 }
 
 provider "google" {
-  project = <PROJECT ID>
+  project = "<project ID>"
 }
 
 terraform {
@@ -57,18 +59,18 @@ terraform {
 
 terraform {
   backend "gcs" {
-    bucket = "<your_globally_unique_bucket_name>" #Replace with the name of the bucket created in Module 0
+    bucket = "<your globally unique bucket name>" #replace with the name of the bucket created in module 0
     prefix = "network-state" #creates a new folder within the bucket
   }
 }
 ```
-Note: Check the [example file](../../terraform/global/1-network/main.tf) for sample subnets name and IPs. The subnet names are required to be in the below format.
+Note: Check the [example file](../../terraform/global/1-network/main.tf) for sample subnet names and IPs. The subnet names are required to be in the below format.
 
 | Required Subnet Name | Description | Required IPs | Sample CIDR Block | Required |
 |------|-------------|------|---------|:--------:|
-| `<environment>-<subnet-region>-subnet` | Subnet for Kubernetes cluster | 1024 | 10.198.0.0/22 | yes |
-| `<environment>-<subnet-region>-vm-subnet` | Subnet for Virtual Machines | 1024 | 10.198.8.0/22 | yes |
-| `<environment>-<subnet-region>-privateep-subnet` | Subnet for Private Endpoints | 1024 | 10.198.4.0/22 | yes |
+| `<network_name>-<subnet-region>-subnet` | subnet for kubernetes cluster | 1024 | 10.198.0.0/22 | yes |
+| `<network_name>-<subnet-region>-vm-subnet` | subnet for virtual machines | 1024 | 10.198.8.0/22 | yes |
+| `<network_name>-<subnet-region>-privateep-subnet` | subnet for private endpoints | 1024 | 10.198.4.0/22 | yes |
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -78,10 +80,9 @@ Note: Check the [example file](../../terraform/global/1-network/main.tf) for sam
 |------|-------------|------|---------|:--------:|
 | provision\_vpc | Flag to create VPC network | `bool` | true | yes |
 | project\_id or project | The ID of the project where these resources will be created | `string` | n/a | yes |
-| network\_name | The name of the network being created; set to "defaul" if not creating VPC | `string` | n/a | yes |
+| network\_name | The name of the network being created | `string` | n/a | yes |
 | description| Optional description | `string` | n/a | no |
-| environment | The environment where these resources will be created | `string` | n/a | yes |
-| region | The region where this these resources will be created | `string` | n/a | yes |
+| region | The region where these resources will be created | `string` | n/a | yes |
 | fqdn | FQDN to be used by DNS | `string` | n/a | yes |
 | subnet | The subnets name, CIDR and regions | `map` | n/a | yes |
 | bucket | Name of the bucket created in module 0 | `string` | n/a | yes |
@@ -97,10 +98,10 @@ Note: Check the [example file](../../terraform/global/1-network/main.tf) for sam
 | network\_id | The ID of the VPC being created |
 | network\_name | The name of the VPC being created |
 | network\_self\_link | The URI of the VPC being created |
-| domain | The DNS zone domain. |
-| name | The DNS zone name. |
-| name\_servers | The DNS zone name servers. |
-| type | The DNS zone type. |
+| domain | The DNS zone domain |
+| name | The DNS zone name |
+| name\_servers | The DNS zone name servers |
+| type | The DNS zone type |
 | router | The created router |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/gcp-gke/tfm/1-network/main.tf
+++ b/gcp-gke/tfm/1-network/main.tf
@@ -13,9 +13,9 @@ resource "google_compute_network" "vpc" {
 # DNS zone creation
 resource "google_dns_managed_zone" "dns-zone" {
   project     = var.project_id
-  name        = "base-dns-global-${var.environment}"
+  name        = "base-dns-global-${var.network_name}"
   dns_name    = var.fqdn
-  description = "base-dns-global-${var.environment}"
+  description = "base-dns-global-${var.network_name}"
   visibility  = "public"
 
   dnssec_config {
@@ -31,7 +31,7 @@ resource "google_dns_managed_zone" "dns-zone" {
 
 resource "google_compute_router" "router" {
   for_each    = toset(var.region)
-  name        = "natrouter-${each.value}-${var.environment}"
+  name        = "natrouter-${each.value}-${var.network_name}"
   network     = var.network_name
   region      = each.value
   project     = var.project_id
@@ -44,9 +44,9 @@ resource "google_compute_router" "router" {
 
 resource "google_compute_router_nat" "nats" {
   for_each                           = toset(var.region)
-  name                               = "natgw-${each.value}-${var.environment}"
+  name                               = "natgw-${each.value}-${var.network_name}"
   project                            = var.project_id
-  router                             = "natrouter-${each.value}-${var.environment}"
+  router                             = "natrouter-${each.value}-${var.network_name}"
   region                             = each.value
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"

--- a/gcp-gke/tfm/1-network/variables.tf
+++ b/gcp-gke/tfm/1-network/variables.tf
@@ -9,14 +9,9 @@ variable "description" {
   default     = ""
 }
 
-variable "environment" {
-  type = string
-  description = "The environment of the project where this VPC will be created" #for reducing a zero in project ID
-}
-
 variable "network_name" {
   type = string
-  description = "VPC Name"
+  description = "VPC network name"
 }
 
 variable "provision_vpc" {

--- a/gcp-gke/tfm/2-gke-cluster/README.md
+++ b/gcp-gke/tfm/2-gke-cluster/README.md
@@ -2,27 +2,28 @@
 
 This module supports creating:
 
-- A Kubernetes Cluster
+- a Kubernetes cluster
 
 ## Usage
 
-We have tested this cluster with gke version 1.22.3-gke.700 which was in Rapid release channel at the time, for the updated release channels and versions please check the official [Release Notes](https://cloud.google.com/kubernetes-engine/docs/release-notes). We are only supporting  Basic usage of this module is as follows:
+We have tested this cluster with GKE version 1.23.10-gke.1000 which was in the RAPID release channel at the time. Use the UNSPECIFIED release channel to prevent cluster auto upgrade. For the updated release channels and versions please check the official [Release Notes](https://cloud.google.com/kubernetes-engine/docs/release-notes). Basic usage of this module is as follows:
 
+
+Note: set the `release_channel` variable to UNSPECIFIED to prevent cluster autoupgrade.
 
 ```hcl
 module "gke" {
-    source                  = "github.com/genesys/multicloud-platform.git//gcp-gke/tfm/2-gke-cluster?ref=master"
-    project_id              = "<project ID> eg.gcpe0003"
-    environment             = "<environment> eg.gcpe003"
-    network_name            = "<network> eg.gcpe003"
-    region                  = "<cluster region> eg.us-west1"
-    cluster                 = "<cluster name> eg.gke1"
-    gke_version             = "<version of the cluster>" #Minumum version supported: 1.22
-    release_channel         = "<release channel> eg.RAPID/REGULAR/STABLE" #must be all caps
-    secondary_pod_range     = "<CIDR block for pods> eg.10.198.64.0/18"
-    secondary_service_range = "<CIDR block for services> 10.198.16.0/20"
+    source                  = "../../../tfm/2-gke-cluster/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/2-gke-cluster?ref=master"
+    project_id              = "<project ID>" #eg. project01
+    network_name            = "<network>" #eg. network01
+    region                  = "<cluster region>" #eg. us-west1
+    cluster                 = "<cluster name>" #eg. cluster01
+    gke_version             = "<version of the cluster>" #minumum version supported: 1.23
+    release_channel         = "<release channel>" #eg. RAPID/REGULAR/STABLE/UNSPECIFIED (must be all caps)
+    secondary_pod_range     = "<CIDR block for pods>" #eg. 10.198.64.0/18
+    secondary_service_range = "<CIDR block for services>" #eg. 10.198.16.0/20
     gke_num_nodes           = "2"
-    windows_node_pool       = false #Optional parameter.Needs to be specified if node pool needs to be windows.By default it is false and will create a GKE cluster with linux node pool.
+    windows_node_pool       = false #Optional parameter. Needs to be specified if node pool needs to be windows. By default it is false and will create a GKE cluster with Linux node pool.
 }
 
 terraform {
@@ -38,8 +39,8 @@ terraform {
 
 terraform {
     backend "gcs" {
-        bucket = "<your_globally_unique_bucket_name>" #Replace with the name of the bucket created in Module 0
-        prefix = "gke-cluster-state" #creates a new folder within the bucket
+        bucket = "<your globally unique bucket name>" #Replace with the name of the bucket created in module 0
+        prefix = "cluster-state" #Creates a new folder within the bucket
     }
 }
 ```
@@ -50,15 +51,14 @@ terraform {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 |project\_id | The ID of the project where these resources will be created | `string` | n/a | yes |
-|environment | The environment where these resources will be created, used for naming conventions | `string` | n/a | yes |
 |network\_name | The name of the network being created; set to "default" if not creating VPC | `string` | n/a | yes |
 |region | The region where this these resources will be created | `string` | n/a | yes |
 |cluster | The name of the GKE cluster | `string` | n/a | yes |
-|gke_version | The version of the GKE cluster; should be equal to or above 1.22 | `string` | n/a | yes |
+|gke_version | The version of the GKE cluster; should be equal to or above 1.23 | `string` | n/a | yes |
 |release_channel | Release channel for the selected gke cluster version | `string` | n/a | yes |
 |secondary_pod_range | The reserved CIDR block for pods | `string` | n/a | yes |
 |secondary_service_range | The reserved CIDR block for services | `string` | n/a | yes |
-|gke_num_nodes | The number of nodes in the k8s cluster in each zone  | `string` | n/a | yes |
+|gke_num_nodes | The number of nodes in the Kubernetes cluster in each zone  | `string` | n/a | yes |
 |windows_node_pool | Flag to provision windows node pool  | `bool` | false| no |
 |bucket | Name of the bucket created in module 0 | `string` | n/a | yes |
 |prefix | Name of folder to be created within bucket | `string` | n/a | yes |
@@ -69,15 +69,15 @@ Reserved IP range details:
 | Pod Ranges | Description | Required IPs | Sample CIDR Block | Required |
 |------|-------------|------|---------|:--------:|
 | `secondary_pod_range` | Reserved IP range for pods | 16384 | 10.198.64.0/18 | yes |
-| `secondary_service_range` |  Reserved IP range for services | 4096 | 10.198.16.0/20 | yes |
+| `secondary_service_range` | Reserved IP range for services | 4096 | 10.198.16.0/20 | yes |
 
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-|kubernetes_cluster_name| the name of the kubernetes cluster|
-|kubernetes_cluster_host| the endpoint for the k8s cluster host|
+|kubernetes_cluster_name| The name of the Kubernetes cluster|
+|kubernetes_cluster_host| The endpoint for the Kubernetes cluster host|
 
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/gcp-gke/tfm/2-gke-cluster/variables.tf
+++ b/gcp-gke/tfm/2-gke-cluster/variables.tf
@@ -1,22 +1,17 @@
 variable "project_id" {
   type = string
-  description = "project id"
-}
-
-variable "environment" {
-  type = string
-  description = "environment"
+  description = "Project ID"
 }
 
 variable "region" {
   type = string
-  description = "region"
+  description = "Region"
 }
 
 
 variable "cluster" {
   type = string
-  description = "cluster name"
+  description = "Cluster name"
 }
 
 variable "gke_version" {
@@ -31,25 +26,25 @@ variable "release_channel" {
 
 variable "secondary_pod_range" {
   type = string
-  description = "CIDR block for Pod IPs"
+  description = "CIDR block for pod IPs"
 }
 
 variable "secondary_service_range" {
   type = string
-  description = "CIDR block for Pod IPs"
+  description = "CIDR block for service IPs"
 }
 
 variable "network_name" {
   type = string
-  description = "the network name of the gke cluster"
+  description = "The network name of the GKE cluster"
 }
 
 variable "gke_num_nodes" {
   type = string
-  description = "the number of nodes in each az"
+  description = "The number of nodes in each availability zone"
 }
 variable "windows_node_pool" {
-  type = bool
+  type        = bool
   default     = false
   description = "Flag to provision windows node pool"
 }

--- a/gcp-gke/tfm/3-k8s-setup/README.md
+++ b/gcp-gke/tfm/3-k8s-setup/README.md
@@ -9,29 +9,29 @@ This module supports creating:
 Basic usage of this module is as follows:
 
 ```hcl
-module "k8s-setup" {
-    source        = "github.com/genesys/multicloud-platform.git//gcp-gke/tfm/3-k8s-setup?ref=master"
-    project_id    = "<PROJECT ID eg.gcpe0002>"
-    network_name  = "<Same as environment>"
-    ipv4          = "<Reserved ipv4 for storage class>" #1024 IP addresses. Example CIDR block 10.198.12.0/22
+module "network" {
+    source        = "../../../tfm/3-k8s-setup/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/3-k8s-setup?ref=master"
+    project_id    = "<project ID>" #eg. project01
+    network_name  = "<name of your VPC network>" #eg. network01
+    ipv4          = "<reserved IPv4 CIDR for storage class>" #1024 IP addresses
 }
 
 
 provider "google" {
-  project = <PROJECT ID>
+  project = "<project ID>"
 }
 
-data "google_container_cluster" "gke1" {
+data "google_container_cluster" "<cluster name>" {
   name = "<cluster name>"
   location = "<cluster region>"
-  project = "<project id>"
+  project = "<project ID>"
 }
 
 provider "kubernetes" {
-  host = "https://${data.google_container_cluster.gke1.endpoint}"
+  host = "https://${data.google_container_cluster.<cluster name>.endpoint}"
   token = data.google_client_config.provider.access_token
   cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
   ) 
 }
 
@@ -45,10 +45,10 @@ default = "v2.9.1"
 
 provider "helm" {
   kubernetes {
-    host = "https://${data.google_container_cluster.gke1.endpoint}"
+    host = "https://${data.google_container_cluster.<cluster name>.endpoint}"
     token = data.google_client_config.provider.access_token
     cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
     )
     config_path = "~/.kube/config"
   } 
@@ -67,8 +67,8 @@ terraform {
 
 terraform {
   backend "gcs" {
-    bucket = "<your_globally_unique_bucket_name>" #Replace with the name of the bucket created in Module 0
-    prefix = "k8s-setup-state" #creates a new folder within the bucket
+    bucket = "<your globally unique bucket name>" #Replace with the name of the bucket created in module 0
+    prefix = "<cluster name>-k8s-state" #Creates a new folder within the bucket
   }
 }
 ```
@@ -80,7 +80,7 @@ terraform {
 |------|-------------|------|---------|:--------:|
 | project\_id or project | The ID of the project where these resources will be created | `string` | n/a | yes |
 | network\_name | The name of the network being created | `string` | n/a | yes |
-| ipv4 | The ipv4 address reserved for the storage class | `string` | n/a | yes |
+| ipv4 | The IPv4 address reserved for the storage class | `string` | n/a | yes |
 | name | Cluster name where resources will be created | `string` | n/a | yes |
 | location | Region of the cluster | `string` | n/a | yes |
 | bucket | Name of the bucket created in module 0 | `string` | n/a | yes |

--- a/gcp-gke/tfm/3-k8s-setup/variables.tf
+++ b/gcp-gke/tfm/3-k8s-setup/variables.tf
@@ -5,14 +5,12 @@ variable "project_id" {
 
 variable "network_name" {
   type = string
-  description = "VPC Name"
+  description = "VPC network name"
 }
 
 
 variable "ipv4" {
   type        = string
-  description = "Resrved CIDR block for storage class"
+  description = "Reserved CIDR block for storage class"
 }
-
-#"10.198.12.0/22"
 

--- a/gcp-gke/tfm/4-ingress-certs/README.md
+++ b/gcp-gke/tfm/4-ingress-certs/README.md
@@ -8,29 +8,28 @@ Basic usage of this module is as follows:
 
 ```hcl
 module "ingress_certs" {
-  source                = "github.com/genesys/multicloud-platform.git//gcp-gke/tfm/4-ingress-certs?ref=master"
-  project_id            = "<project id>" eg.gcpe0003
-  environment           = "<The environment where these resources will get created>" eg.gcpe003
-  domain_name_nginx     = "<domain name>" 
-  cert_manager_version  = "1.5.4"
-  email                 = "<john@example.com>"
+  source            = "../../../tfm/4-ingress-certs/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/4-ingress-certs?ref=master"
+  project_id        = "<project ID>" #eg. project01
+  network_name      = "<name of the VPC network>" #eg. network01
+  domain_name_nginx = "<domain name>" #eg. lb01-useast1.domain.example.com (domain.example.com should be same as FQDN in module 1)
+  email             = "<email for certificate issuers>" #eg. jane.doe@email.com
 }
 
 #Kubernetes
 
 data "google_client_config" "provider" {}
 
-data "google_container_cluster" "gke1" {
+data "google_container_cluster" "<cluster name>" {
   name = "<cluster name>"
   location = "<cluster region>"
   project = "<project ID>"
 }
 
 provider "kubernetes" {
-  host = "https://${data.google_container_cluster.gke1.endpoint}"
+  host = "https://${data.google_container_cluster.<cluster name>.endpoint}"
   token = data.google_client_config.provider.access_token
   cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
   ) 
 }
 
@@ -42,10 +41,10 @@ default = "v2.9.1"
 
 provider "helm" {
   kubernetes {
-    host = "https://${data.google_container_cluster.gke1.endpoint}"
+    host = "https://${data.google_container_cluster.<cluster name>.endpoint}"
     token = data.google_client_config.provider.access_token
     cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
     )
     config_path = "~/.kube/config"
   } 
@@ -53,7 +52,7 @@ provider "helm" {
 
 
 provider "google" {
-  project = <PROJECT ID>
+  project = <project ID>
 }
 
 terraform {
@@ -69,8 +68,8 @@ terraform {
 
 terraform {
   backend "gcs" {
-    bucket =  "<your_globally_unique_bucket_name>"  #Replace with the name of the bucket created in Module 0
-    prefix = "ingress-certs-state" #creates a new folder within the bucket
+    bucket =  "<your globally unique bucket name>"  #Replace with the name of the bucket created in module 0
+    prefix = "ingress-state" #Creates a new folder within the bucket
   }
 }
 
@@ -83,7 +82,7 @@ terraform {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | project_id or project | The project ID to deploy to | `string` | n/a | yes |
-| environment | The environment where these resources will be created, used for naming conventions | `string` | n/a | yes |
+| network_name | Name of the VPC network where these resources will be created | `string` | n/a | yes |
 | domain_name_nginx | Load balancer domain name | `string` | n/a | yes |
 | email | Email address for certificate issuers | `string` | n/a | yes |
 | cert_manager_version | Certificate manager version | `string` | 1.5.4 | no |

--- a/gcp-gke/tfm/4-ingress-certs/main.tf
+++ b/gcp-gke/tfm/4-ingress-certs/main.tf
@@ -22,7 +22,7 @@ data "kubernetes_service" "ingress-nginx_controller" {
 
 # DNS zone managed by Google Cloud DNS.
 data "google_dns_managed_zone" "default" {
-  name = "base-dns-global-${var.environment}"
+  name = "base-dns-global-${var.network_name}"
   project     = var.project_id
 }
 

--- a/gcp-gke/tfm/4-ingress-certs/variables.tf
+++ b/gcp-gke/tfm/4-ingress-certs/variables.tf
@@ -1,11 +1,11 @@
 variable "project_id" {
   type = string
-  description = "The ID of the project where  these resources will get created"
+  description = "The ID of the project where these resources will get created"
 }
 
-variable "environment" {
+variable "network_name" {
   type = string
-  description = "The environment where these resources will get created"
+  description = "The VPC network where resources will get created"
 }
 
 
@@ -16,11 +16,11 @@ variable "domain_name_nginx" {
 
 variable "cert_manager_version" {
   type        = string
-  description = "cert manager version"
-  default    = "1.5.4"
+  description = "Cert manager version"
+  default     = "1.5.4"
 }
 
 variable "email" {
   type        = string
-  description = "email address to be used for certificate issuers"
+  description = "Email address to be used for certificate issuers"
 }

--- a/gcp-gke/tfm/5-third-party/README.md
+++ b/gcp-gke/tfm/5-third-party/README.md
@@ -3,9 +3,9 @@
 This module supports creating:
 
 All third party software that we want to install on the k8s cluster:
-- Kafka
-- Keda
-- Consul
+- Kafka - v2.7.0
+- Keda  -  v2.6.1
+- Consul - v1.9.15
 
 ## Usage
 
@@ -13,22 +13,26 @@ Basic usage of this module is as follows:
 
 ```hcl
 module "third-party" {
-    source  = "github.com/genesys/multicloud-platform.git//gcp-gke/tfm/5-third-party?ref=master"
+    source  = "../../../tfm/5-third-party/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/5-third-party?ref=master"
+    consul_helm_version = "0.41.0"
+    consul_image        = "hashicorp/consul:1.11.3"
+    consul_imageK8S     = "hashicorp/consul-k8s-control-plane:0.41.0"
+    consul_datacenter   = "useast1"
 }
 
 #Kubernetes
 data "google_client_config" "provider" {}
-data "google_container_cluster" "gke1" {
+data "google_container_cluster" "<cluster name>" {
   name     = <cluster name>
   location = <cluster location>
-  project  = <project name>
+  project  = <project ID>
 }
 
 provider "kubernetes" {
-  host  = "https://${data.google_container_cluster.gke1.endpoint}"
+  host  = "https://${data.google_container_cluster.<cluster name>.endpoint}"
   token = data.google_client_config.provider.access_token
   cluster_ca_certificate = base64decode(
-    data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
     #google_container_cluster.primary.master_auth.0.cluster_ca_certificate
   )
 }
@@ -41,10 +45,10 @@ variable "helm_version" {
 provider "helm" {
 
   kubernetes {
-    host  = "https://${data.google_container_cluster.gke1.endpoint}"
+    host  = "https://${data.google_container_cluster.<cluster name>.endpoint}"
     token = data.google_client_config.provider.access_token
     cluster_ca_certificate = base64decode(
-      data.google_container_cluster.gke1.master_auth[0].cluster_ca_certificate,
+      data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
       #google_container_cluster.primary.master_auth.0.cluster_ca_certificate
     )
     config_path = "~/.kube/config"
@@ -52,7 +56,7 @@ provider "helm" {
 }
 
 provider "google" {
-  project = <project name>
+  project = <project ID>
 }
 
 terraform {
@@ -68,11 +72,15 @@ terraform {
 
 terraform {
     backend "gcs" {
-        bucket = "<your_globally_unique_bucket_name>" #Replace with the name of the bucket created in Module 0
-        prefix = "third-party-state" #creates a new folder within bucket
+        bucket = "<your globally unique bucket name>" #Replace with the name of the bucket created in module 0
+        prefix = "third-party-state" #Creates a new folder within bucket
     }
 }
 ```
+
+
+
+
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
@@ -82,10 +90,34 @@ Below inputs are required in the data and provider blocks and not in the module 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | name | The name of the cluster  | `string` | n/a | yes |
+| consul_helm_version | Consul version to be installed  | `string` | "v0.34.1"| no |
+| consul_image | Consul image to be used in helm  | `string` | "hashicorp/consul:1.9.15"| no |
+| consul_imageK8s | Consul Kubernetes image  to be installed  | `string` | "hashicorp/consul-k8s-control-plane:0.34.1"| no |
+| consul_datacenter | Consul datacenter name (equivalent to cluster region)  | `string` | n/a | yes |
+| tls | Enable TLS in Consul  | `string` | true | no |
 | location | The region of the cluster  | `string` | n/a | yes |
 | project | The name of the project  | `string` | n/a | yes |
 | bucket | Name of the bucket created in module 0 | `string` | n/a | yes |
 | prefix | Name of folder to be created within bucket | `string` | n/a | yes |
+
+
+
+## Consul Compatability Matrix and Variable Values
+| GKE Verson | Consul Version |
+|------------|----------------|
+| v1.21 | v1.9.15 |
+| >= v1.22 | v1.11.3 |
+
+| Consul Variables | v1.9.15 Values | v1.11.3 Values |
+|------------------|----------------|----------------|
+| consul_helm_version | "v0.34.1" | "0.41.0" |
+| consul_image | "hashicorp/consul:1.9.15" | "hashicorp/consul:1.11.3" |
+| consul_imageK8s | "hashicorp/consul-k8s-control-plane:0.34.1" | "hashicorp/consul-k8s-control-plane:0.41.0" |
+| tls | true | true |
+
+
+
+
 
 
 

--- a/gcp-gke/tfm/5-third-party/consul-values.yaml
+++ b/gcp-gke/tfm/5-third-party/consul-values.yaml
@@ -1,36 +1,115 @@
 global:
+  logLevel: info
   name: consul
-  datacenter: dc1
-  #image: registry.connect.redhat.com/hashicorp/consul:1.9.10-ubi 
-  #imageK8S: registry.connect.redhat.com/hashicorp/consul-k8s-control-plane:0.34.0-ubi
+  domain: useast1.consul #variable
+  datacenter: useast1
+  image: hashicorp/consul:1.11.3
+  imageK8S: hashicorp/consul-k8s-control-plane:0.41.0
   tls:
     enabled: true
     enableAutoEncrypt: true
     httpsOnly: false
   acls:
     manageSystemACLs: true
+  gossipEncryption:
+    autoGenerate: true
   openshift:
-    enabled: true
-
+    enabled: false
 server:
-  replicas: 1
-  bootstrapExpect: 1
+  replicas: 3
+  bootstrapExpect: 3
+
+  resources:
+    requests:
+      memory: 100Mi
+      cpu: 1
+    limits:
+      memory: 1Gi
+      cpu: 2
   disruptionBudget:
     enabled: true
     maxUnavailable: 0
-
+  securityContext:
+    runAsNonRoot: false
+    runAsGroup: 0
+    runAsUser: 0
+    fsGroup: 0
 client:
   enabled: true
   grpc: true
-
-ui:
-  enabled: true 
-
-connectInject:
+  image: 
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "800m"
+    limits:
+      memory: "2560Mi"
+      cpu: "800m"
+  extraConfig: |
+    {
+      "telemetry": {
+        "disable_hostname": true
+      }
+    }
+dns:
   enabled: true
-
+  enableRedirection: true
+ui:
+  enabled: true
+connectInject:
+  sidecarProxy:
+    resources:
+      requests:
+        memory: "150Mi"
+        cpu: "400m"
+      limits:
+        memory: "600Mi"
+        cpu: "800m"
+  enabled: true
+  transparentProxy:
+    defaultEnabled: false
+    defaultOverwriteProbes: false
+  metrics:
+    defaultEnabled: false  
+  topologySpreadConstraints: |
+    - maxSkew: 1
+      topologyKey: failure-domain.beta.kubernetes.io
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          labelname: labelvalue
+  tolerations: |
+    - key: CriticalAddonsOnly
+      operator: Exists
+      effect: NoSchedule
+  resources:
+    requests:
+      memory: "400Mi"
+      cpu: "400m"
+    limits:
+      memory: "2000Mi"
+      cpu: "400m"
 controller:
   enabled: true
-  
+  replicas: 2
+  topologySpreadConstraints: |
+    - maxSkew: 1
+      topologyKey: failure-domain.beta.kubernetes.io
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          labelname: labelvalue
+  tolerations: |
+    - key: CriticalAddonsOnly
+      operator: Exists
+      effect: NoSchedule
 syncCatalog:
   enabled: true
+  addK8SNamespaceSuffix: false
+  resources:
+    requests:
+      memory: "200Mi"
+      cpu: "400m"
+    limits:
+      memory: "800Mi"
+      cpu: "800m"

--- a/gcp-gke/tfm/5-third-party/main.tf
+++ b/gcp-gke/tfm/5-third-party/main.tf
@@ -34,7 +34,7 @@ resource "helm_release" "keda" {
   repository   = "https://kedacore.github.io/charts"
   chart       = "keda"
   namespace   = "keda"
-  version     = "2.0.1"
+  version     = "2.6.2"
 }
 
 
@@ -61,10 +61,11 @@ resource "helm_release" "consul" {
   max_history   = 10
   wait          = true
   recreate_pods = true
-  version  = "v0.37.0"
+  version       =  var.consul_helm_version
   values        = [
     data.local_file.helmvalues-consul.content
   ]
+
 
   set {
     name  = "global.tls.enabled"
@@ -73,7 +74,7 @@ resource "helm_release" "consul" {
 
   set {
     name  = "global.acls.manageSystemACLs"
-    value = true
+    value = var.manageSystemACLs
   }
 
   set {
@@ -90,21 +91,43 @@ resource "helm_release" "consul" {
     value = var.controller
   }
   set {
-    name  = "openshift.enabled"
-    value = var.controller
+    name  = "global.openshift.enabled"
+    value = var.openshift
   }
   set {
     name  = "syncCatalog.enabled"
-    value = var.controller
+    value = var.syncCatalog
   }
   set {
     name  = "ui.enabled"
-    value = var.controller
+    value = var.ui
   }
   set {
     name  = "client.enabled"
-    value = var.controller
+    value = var.client
   }
+
+  set {
+    name  = "global.image"
+    value = var.consul_image
+  }
+
+  set {
+    name  = "global.imageK8S"
+    value = var.consul_imageK8S
+  }
+
+
+  set {
+    name  = "global.datacenter"
+    value = var.consul_datacenter
+  }
+
+  set {
+    name = "global.domain"
+    value = "${var.consul_datacenter}.consul"
+  }
+
   depends_on = [
     kubernetes_namespace.consul,
   ]

--- a/gcp-gke/tfm/5-third-party/variables.tf
+++ b/gcp-gke/tfm/5-third-party/variables.tf
@@ -2,15 +2,15 @@
 #variable chartValues    { default = "" }
 
 variable tls {
-  default = false
+  default = true
 }
 
 variable connectInject {
-  default = false
+  default = true
 }
 
 variable controller {
-  default = false
+  default = true
 }
 
 variable openshift {
@@ -18,13 +18,36 @@ variable openshift {
 }
 
 variable syncCatalog {
-  default = false
+  default = true
 }
 
 variable ui {
-  default = false
+  default = true
 }
 
 variable client {
-  default = false
+  default = true
+}
+
+variable manageSystemACLs {
+  default = true
+}
+
+variable consul_helm_version {
+  type = string
+  default = "v0.34.1"
+}
+
+variable consul_image {
+  type = string
+  default = "hashicorp/consul:1.9.15"
+}
+
+variable consul_imageK8S {
+  type = string
+  default = "hashicorp/consul-k8s-control-plane:0.34.1"
+}
+
+variable consul_datacenter {
+  type = string
 }

--- a/gcp-gke/tfm/6-jumphost/README.md
+++ b/gcp-gke/tfm/6-jumphost/README.md
@@ -16,15 +16,15 @@ Basic usage of this module is as follows. Firewall rules and custom IAM role nee
 
 ```hcl
 module "jumphost_instance" {
-    source          = "github.com/genesys/multicloud-platform.git//gcp-gke/tfm/6-jumphost?ref=master"
-    project         = "<PROJECT ID>" eg.gcpe0003
-    description     = "<Optional Description>"
-    name            = "<your_machine_name>"
-    machine_type    = "<Machine_tyep>" eg.e2-micro
-    zone            = "<zone>" eg.us-central1-a   
-    image           = "<OS_image_name>" eg.ubuntu-os-cloud/ubuntu-1804-lts
-    network         = "<VPC Network ID>"
-    subnetwork      = "<Subnet of Network>"
+    source          = "../../../tfm/6-jumphost/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/6-jumphost?ref=master"
+    project         = "<project ID>" #eg. project01
+    description     = "<optional description>"
+    name            = "<your machine name>" #eg. cluster01-jumphost
+    machine_type    = "<machine type>" #eg. e2-micro
+    zone            = "<zone>" #eg. us-central1-a   
+    image           = "<OS image name>" #eg. ubuntu-os-cloud/ubuntu-1804-lts
+    network         = "<VPC network name>" #eg. network01
+    subnetwork      = "<subnet of network>"
     provision_ssh_firewall = true
     provision_iap_firewall = true
     create_iap_iam_role    = true
@@ -33,7 +33,7 @@ module "jumphost_instance" {
 }
 
 provider "google" {
-  project = "<PROJECT ID>"
+  project = "<project ID>"
 }
 
 terraform {
@@ -49,8 +49,8 @@ terraform {
 
 terraform {
   backend "gcs" {
-    bucket = "<your_globally_unique_bucket_name>" #Replace with the name of the bucket created in Module 0
-    prefix = "jumphost-state" #creates a new folder within bucket
+    bucket = "<your globally unique bucket name>"  #Replace with the name of the bucket created in Module 0
+    prefix = "jumphost-state" #Creates a new folder within bucket
   }
 }
 ```
@@ -63,16 +63,16 @@ terraform {
 |------|-------------|------|---------|:--------:|
 | project | The ID of the project where these resources will be created | `string` | n/a | yes |
 | description| Optional description | `string` | n/a | no |
-| name| Instance Name | `string` | n/a | yes |
+| name| Instance name | `string` | n/a | yes |
 | machine_type| Compute capacity of instance | `string` | n/a | yes |
 | zone   | The zone that the machine should be created in | `string` | n/a | yes |
-| image| OS image like ubuntu/RHEL/windows | `string` | n/a | yes |
-| network | The name of the network where Instance to deployed; set to "default" if not specific VPC | `string` | n/a | yes |
+| image| OS image like Ubuntu/RHEL/Windows | `string` | n/a | yes |
+| network | The name of the network where instance is to be deployed; set to "default" if not specific VPC | `string` | n/a | yes |
 | subnetwork | The name of the subnetwork where Instance to deployed in network; set to "default" if not specific subnetwork | `string` | n/a | yes |
 | provision_ssh_firewall  | Flag variable for creating an SSH allowing firewall rule | `bool` | true | no |
 | provision_iap_firewall  | Flag variable for creating an IAP allowing firewall rule | `bool` | true | no |
 | create_iap_iam_role  | Flag variable for creating an custom IAM role for IAP access| `bool` | true | no |
-| members  | list of members who need IAP access | `list` | n/a | no |
+| members  | List of members who need IAP access | `list` | n/a | no |
 | bucket | Name of the bucket created in module 0 | `string` | n/a | yes |
 | prefix | Name of folder to be created within bucket | `string` | n/a | yes |
 

--- a/gcp-gke/tfm/6-jumphost/main.tf
+++ b/gcp-gke/tfm/6-jumphost/main.tf
@@ -86,11 +86,11 @@ resource "google_project_iam_custom_role" "IAP_tunnel_users" {
 }
 
 resource "google_project_iam_binding" "project" {
-  project = var.project
-  role    = google_project_iam_custom_role.IAP_tunnel_users.id 
-  members = var.members
-
-  depends_on = [
+  count       = var.create_iap_iam_role == true ? 1 : 0
+  project     = var.project
+  role        = "projects/${var.project}/roles/IAPusers"
+  members     = var.members
+  depends_on  = [
     google_project_iam_custom_role.IAP_tunnel_users
   ]
 }

--- a/gcp-gke/tfm/6-jumphost/variables.tf
+++ b/gcp-gke/tfm/6-jumphost/variables.tf
@@ -1,20 +1,20 @@
 variable "project" {
     type = string
-    description = "project name"
+    description = "Project name"
 }
 variable "description" {
     default = ""
     type = string
-    description = "Optional description for Jumphost"
+    description = "Optional description for jumphost"
 }
 variable "machine_type" {
   type = string
-  description = "Type of machine to be used for Jumphost"
+  description = "Type of machine to be used for jumphost"
 }
 
 variable "name" {
   type = string
-  description = "This is bastion host name"
+  description = "Bastion host name"
   
 }
 
@@ -31,31 +31,31 @@ variable "image" {
 
 variable "network" {
   type = string
-  description = "select network vm to be launched"
+  description = "Network where VM will be launched"
 
 }
 
 variable "subnetwork" {
   type = string
-  description = "part of network"
+  description = "Part of network"
 }
 
 
 variable "provision_ssh_firewall" {
   type = bool
-  description = "Flag for creating a firewall rule"
+  description = "flag for creating a firewall rule"
   default     = true
 }
 
 variable "provision_iap_firewall" {
   type = bool
-  description = "Flag for creating a firewall rule"
+  description = "flag for creating a firewall rule"
   default     = true
 }
 
 variable "create_iap_iam_role" {
   type = bool
-  description = "Flag for creating a firewall rule"
+  description = "Flag for creating an IAP IAM role"
   default     = true
 }
 

--- a/gcp-gke/tfm/7-sbc/README.md
+++ b/gcp-gke/tfm/7-sbc/README.md
@@ -1,0 +1,12 @@
+# Terraform SBC Module
+
+This module supports creating SBC configurations.
+
+## Usage
+
+Order of execution:
+1. sbc-peering
+2. sbc-setup
+
+
+

--- a/gcp-gke/tfm/7-sbc/sbc-peering/README.md
+++ b/gcp-gke/tfm/7-sbc/sbc-peering/README.md
@@ -1,0 +1,62 @@
+# Terraform step two Module
+
+This module supports creating a VPC peering connection between kubernetes cluster VPC (VPC1) in Project1 and SBC VPC (VPC2) in Project2.
+
+## Usage
+
+This module needs to be executed twice. First in project1 to create a peering connection from VPC1 and VPC2 followed by execution in project2 to create a reverse peering connection from VPC2 to VPC1.
+
+*Note: When executing this module in the second project, change the name of the peering connection and switch the primary and peer VPC/project variable values.
+
+```hcl
+module "network-peering" {
+  source                   = "../../../tfm/7-sbc/sbc-peering/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/7-sbc/sbc-peering?ref=master"
+  peering_connection_name  = <name of the peering connection> #eg. "project01-to-sbc-peer"
+  primary_project          = <name of the primary project> #eg. "project01"
+  primary_vpc              = <name of the primary VPC in primary_project> #eg. "network01"
+  peer_project             = <name of the peer project> #eg. "sbc-project"
+  peer_vpc                 = <name of the peer VPC in peer_project>" #eg. "sbc-network"
+}
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "3.52.0"
+    }
+  }
+
+  required_version = "= 1.0.11"
+}
+
+terraform {
+  backend "gcs" {
+    bucket = "<your globally unique bucket name>" #Replace with the name of the bucket created in module 0 or a bucket in the corresponding project
+    prefix = "peering-state-sbc"    #Creates a new folder
+  }
+}
+
+provider "google" {
+  project = "<project ID>"
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| peering_connection_name | Name of the peering connection | `string` | n/a | yes |
+| primary_project | Primary project to create a peering connection from | `string` | n/a | yes |
+| primary_vpc | Primary VPC to create a peering connection from | `string` | n/a | yes |
+| peer_project | Peer project to create a peering connection to | `string` | n/a | yes |
+| peer_vpc | Peer VPC to create a peering connection to | `string` | n/a | yes |
+| project | Name of the project in provider block where the resources will be created | `string` | n/a | yes |
+| bucket | Same as globally unique bucket name | `string` | n/a | yes |
+| prefix | Name of folder to be created within bucket | `string` | n/a | yes |
+
+
+
+## Links
+Additional information on how to provide the path to the 
+peer network that belongs in another project can be found [here.](https://stackoverflow.com/questions/54789215/terraform-gcp-vpc-peering)

--- a/gcp-gke/tfm/7-sbc/sbc-peering/main.tf
+++ b/gcp-gke/tfm/7-sbc/sbc-peering/main.tf
@@ -1,0 +1,39 @@
+# This module manages network peering, both networks must create a peering with
+# each other for the peering to be functional.
+
+
+data "google_compute_network" "primary_network" {
+  name    = var.primary_vpc
+  project = var.primary_project
+}
+
+data "google_compute_network" "peer_network" {
+  name    = var.peer_vpc
+  project = var.peer_project
+}
+
+resource "google_compute_network_peering" "peering1" {
+  name         = var.peering_connection_name
+  network      = data.google_compute_network.primary_network.self_link
+  peer_network = data.google_compute_network.peer_network.self_link
+}
+
+resource "google_compute_firewall" "firewall" {
+  count = var.provision_firewall == true ? 1 : 0
+  name    = "peering-firewall-rule"
+  network = data.google_compute_network.primary_network.self_link
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "3389", "5080"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["5080"]
+  }
+}

--- a/gcp-gke/tfm/7-sbc/sbc-peering/variables.tf
+++ b/gcp-gke/tfm/7-sbc/sbc-peering/variables.tf
@@ -1,0 +1,25 @@
+variable "primary_project" {
+  description = "Primary project to create a peering connection from"
+}
+
+variable "primary_vpc" {
+  description = "Primary VPC to create a peering connection from"
+}
+
+variable "peer_project" {
+  description = "Peer project to create a peering connection to"
+}
+
+variable "peer_vpc" {
+  description = "Peer VPC to create a peering connection to"
+}
+
+variable "peering_connection_name" {
+  description = "Name of network"
+}
+
+variable "provision_firewall_ingress" {
+  type = bool
+  description = "Flag for creating a firewall rule"
+  default     = true
+}

--- a/gcp-gke/tfm/7-sbc/sbc-setup/README.md
+++ b/gcp-gke/tfm/7-sbc/sbc-setup/README.md
@@ -1,0 +1,97 @@
+# SBC Setup
+
+This module handles:
+- reserving an IP for load balancer
+- creating ingress firewall rule
+- creating an internal load balancer
+
+## Usage
+
+Basic usage of this module is as follows:
+
+```hcl
+module "sbc-setup" {
+  source               = "../../../tfm/7-sbc/sbc-setup/" #"github.com/genesys/multicloud-platform.git//gcp-gke/tfm/7-sbc/sbc-setup?ref=master"
+  network_name         = "<name of VPC network for firewall rule>" #eg. network01
+  ip_name              = "<name for the reserved IP address>" #eg. sip-address-useast1
+  subnetwork           = "<name of subnetwork for reserving internal IP>" #eg. network01-us-east1-subnet
+  region               = "<subnet region for internal IP>" #eg. us-east1
+  provision_firewall_ingress   = true/false
+  ip_source_ranges     = "<source IP address ranges for ingress traffic (CIDR format)>" #Optional. Default set to allow all (0.0.0.0/0)
+  tcp_ingress_ports    = [<ports to allow ingress TCP traffic on>] #Optional. Default set to ["22", "3389", "5080"]
+  udp_ingress_ports    = [<ports to allow ingress UDP traffic on>] #Optional. Default set to ["53", "5080"]
+}
+
+#Kubernetes
+
+data "google_client_config" "provider" {}
+
+data "google_container_cluster" "<cluster name>" {
+  name = "<cluster name>"
+  location = "<cluster region>"
+  project = "<project ID>"
+}
+
+provider "kubernetes" {
+  host = "https://${data.google_container_cluster.<cluster name>.endpoint}"
+  token = data.google_client_config.provider.access_token
+  cluster_ca_certificate = base64decode(
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
+  ) 
+}
+
+#Helm
+
+variable "helm_version" {
+default = "v2.9.1"
+}
+
+provider "helm" {
+  kubernetes {
+    host = "https://${data.google_container_cluster.<cluster name>.endpoint}"
+    token = data.google_client_config.provider.access_token
+    cluster_ca_certificate = base64decode(
+    data.google_container_cluster.<cluster name>.master_auth[0].cluster_ca_certificate,
+    )
+    config_path = "~/.kube/config"
+  } 
+}
+
+
+provider "google" {
+  project = <project ID>
+}
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "3.52.0"
+    }
+  }
+
+  required_version = "= 1.0.11"
+}
+
+terraform {
+  backend "gcs" {
+    bucket =  "<your globally unique bucket name>"  #replace with the name of the bucket created in module 0
+    prefix = "sbc-setup-state" #creates a new folder within the bucket
+  }
+}
+
+
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| network_name | Network for firewall rule | `string` | n/a | yes |
+| ip_name | Name for reserved IP address | `string` | n/a | yes |
+| subnetwork | Subnetwork for reserving internal IP | `string` | n/a | yes |
+| region | Subnet region for internal IP | `string` | n/a | yes |
+| provision_firewall_ingress | Flag for creating a firewall rule | `bool` | true | no |
+| ip_source_ranges | Source IP address ranges for ingress traffic (CIDR format) | `string` | "0.0.0.0/0" | no |
+| tcp_ingress_ports | Ports to allow ingress TCP traffic on | `list` | ["22", "3389", "5080"] | no |
+| udp_ingress_ports | Ports to allow ingress UDP traffic on | `list` | ["53", "5080"] | no|

--- a/gcp-gke/tfm/7-sbc/sbc-setup/main.tf
+++ b/gcp-gke/tfm/7-sbc/sbc-setup/main.tf
@@ -1,0 +1,54 @@
+resource "google_compute_address" "lb-ip" {
+  name          = var.ip_name
+  address_type = "INTERNAL"
+  subnetwork   = var.subnetwork
+  region       = var.region
+
+
+}
+
+resource "google_compute_firewall" "firewall-ingress" {
+  count         = var.provision_firewall_ingress == true ? 1 : 0
+  name          = "firewall-rule-ingress"
+  network       = var.network_name
+  # source_ranges = var.ip_source_ranges
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+    ports = var.tcp_ingress_ports
+  }
+
+  allow {
+    protocol = "udp"
+    ports = var.udp_ingress_ports
+  }
+}
+
+resource "kubernetes_service" "kubeDNSLB" {
+  metadata {
+    name      = "kube-dns-lb"
+    namespace = "kube-system"
+    annotations = {
+      "networking.gke.io/load-balancer-type" : "Internal"
+      "networking.gke.io/internal-load-balancer-allow-global-access" : "true"
+    }
+  }
+  spec {
+    type             = "LoadBalancer"
+    session_affinity = "None"
+    load_balancer_ip = google_compute_address.lb-ip.address
+    port {
+      name        = "dns"
+      port        = "53"
+      protocol    = "UDP"
+      target_port = "dns"
+    }
+    selector = {
+      k8s-app = "kube-dns"
+    }
+  }
+}

--- a/gcp-gke/tfm/7-sbc/sbc-setup/variables.tf
+++ b/gcp-gke/tfm/7-sbc/sbc-setup/variables.tf
@@ -1,0 +1,36 @@
+variable "network_name" {
+  description = "Name of the VPC network for firewall rule"
+}
+
+variable "ip_name" {
+  description = "Name for the reserved IP address"
+}
+
+variable "subnetwork" {
+  description = "Subnetwork for reserving internal IP"
+}
+
+variable "region"{
+  description = "Subnet region for internal IP"
+}
+
+variable "provision_firewall_ingress" {
+  type        = bool
+  description = "Flag for creating a firewall rule"
+  default     = true
+}
+
+variable "ip_source_ranges" {
+  description = "Source IP address ranges for ingress traffic (CIDR format)"
+  default = "0.0.0.0/0"
+}
+
+variable "tcp_ingress_ports" {
+  description = "Ports to allow ingress TCP traffic on"
+  default     = ["22", "3389", "5080"]
+}
+
+variable "udp_ingress_ports" {
+  description = "Ports to allow ingress UDP traffic on"
+  default     = ["53", "5080"]
+}


### PR DESCRIPTION
- Adding code for SBC setup. VPC peering, firewall, reserve IP address and creating a LB with global forwarding rules.
- Changes to Consul configuration to support consul data center naming and TLS automation.
- Cleaning readme and variable files
- Removing environment variable in terraform `(var.environment)` and using `var.networ_name` instead